### PR TITLE
Police Sans Serif

### DIFF
--- a/graphical_design.md
+++ b/graphical_design.md
@@ -20,3 +20,6 @@ Labels
 	 - Par défaut à gauche
 	 - Au dessus pour un affichage compressé
 
+Police Sans Serif
+=================
+Les polices Sans Serifs sont généralement utilisés pour les titres et le corps du texte. 


### PR DESCRIPTION
Les polices Sans Serifs sont généralement utilisés pour les titres et le corps du texte.
